### PR TITLE
Set default parameters for loglikelihood func

### DIFF
--- a/helpers/layers/log_reg.py
+++ b/helpers/layers/log_reg.py
@@ -89,7 +89,7 @@ class LogisticRegression(object):
         # parameters of the model
         self.params = [self.W, self.b]
 
-    def negative_log_likelihood(self, y, p_c, care_classes):
+    def negative_log_likelihood(self, y, p_c=None, care_classes=None):
         """Return the mean of the negative log-likelihood of the prediction
         of this model under a given target distribution.
 


### PR DESCRIPTION
The code in the master branch is not working because the calls to the log_likelihood function have 2 parameters and the function requires 4.

I set the default value for the last parameters to None
